### PR TITLE
Support Windows path separator

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function tree(filenames, mapper, callback) {
   }, function(err, object) {
     if (err) return callback(err)
 
-    object = flat.unflatten(object, { delimiter: '/' })
+    object = flat.unflatten(object, { delimiter: path.sep })
 
     callback(null, clean(reformat(object, 'name')))
   })


### PR DESCRIPTION
Windows use '\' for its path separator.

This simple patch fixes disc's compatibility for Windows as well.
