### PR TITLE
Don't attempt to operate on null objects.

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function tree(filenames, mapper, callback) {
 }
 
 function reformat(object, namekey) {
-  if (typeof object !== 'object') return object
+  if (typeof object !== 'object' || object === null) return object
   if (object.__deepest_node__) return object
 
   var entries = []
@@ -51,7 +51,7 @@ function reformat(object, namekey) {
 }
 
 function clean(object) {
-  if (typeof object !== 'object') return object
+  if (typeof object !== 'object' || object === null) return object
   delete object.__deepest_node__
   for (var key in object) {
     clean(object[key])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-tree",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Generate a tree of file metadata that matches d3's hierarchy layout format",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi @hughsk 

I was running into an error when passing in a complex object created by a third party library, turns out that some keys were null, so passed the `typeof object !== 'object'` test but caused an error to be thrown when they were operated on e.g. with `delete`.
